### PR TITLE
Insert media query on tag header

### DIFF
--- a/app/public/css/app.css
+++ b/app/public/css/app.css
@@ -54,3 +54,19 @@
    padding: 10px;
    text-align: center;
  }
+
+  /* Mídia query para dispositivos com largura menor que 480px */
+  @media (max-width: 480px) {
+    header {
+      padding: 10px;
+    }
+
+    header nav ul {
+      flex-direction: column;
+    }
+
+    header nav ul li {
+      margin-bottom: 10px;
+      text-align: center;
+    }
+  }


### PR DESCRIPTION
Adicionamos uma regra de mídia query para dispositivos com largura menor que 480px. Dentro dessa regra, ajustamos os estilos do <header> para melhorar a visualização em telas menores:

Reduzimos o padding do <header> para padding: 10px; para economizar espaço.
Alteramos a direção da lista <ul> para flex-direction: column; para exibi-la verticalmente.
Adicionamos uma margem inferior aos itens da lista <li> com `margin-bottom: 10